### PR TITLE
Allow vendor_init to set property of logpersistd_logging_prop

### DIFF
--- a/sepolicy/vendor/vendor_init.te
+++ b/sepolicy/vendor/vendor_init.te
@@ -14,3 +14,6 @@ allow vendor_init block_device:lnk_file setattr;
 
 # Allow vendor_init to set persist_camera_prop
 set_prop(vendor_init, persist_camera_prop)
+
+# Allow vendor_init to set property of logpersistd_logging_prop
+set_prop(vendor_init, logpersistd_logging_prop)


### PR DESCRIPTION
04-28 23:34:48.253  5789  5789 W ndroid.settings: type=1400 audit(0.0:183): avc: denied { read } for name="u:object_r:logpersistd_logging_prop:s0" dev="tmpfs" ino=19551 scontext=u:r:system_app:s0 tcontext=u:object_r:logpersistd_logging_prop:s0 tclass=file permissive=0
04-28 23:34:48.266  5789  5789 E libc    : Access denied finding property "logd.logpersistd.enable"
04-28 23:34:48.267  5789  5789 W libc    : Unable to set property "persist.logd.logpersistd.buffer" to "": error code: 0x18Allow vendor_init to set property of logpersistd_logging_prop

Bug: 131281328
Test: flash selinux modules to device and reboot under enforcing mode, check if the avc denied log exists
Change-Id: I3cfabeed9e5a76ab9502ef3934e941bac56bcf24